### PR TITLE
Adding codeship build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # NaaSgul
 Notifications as a service engine.
+[ ![Codeship Status for eriktate/NaaSgul](https://codeship.com/projects/b70bd3f0-f301-0133-7f02-16a4a456a383/status?branch=master)](https://codeship.com/projects/149647)


### PR DESCRIPTION
This is a test for the codeship integration which also adds the codeship build status to the README.
