### PR TITLE
Basic websocket prototype (bad/spaghetti code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # NaaSgul
-Notifications as a service engine.
 [ ![Codeship Status for eriktate/NaaSgul](https://codeship.com/projects/b70bd3f0-f301-0133-7f02-16a4a456a383/status?branch=master)](https://codeship.com/projects/149647)
+
+Notifications as a service engine.

--- a/main.go
+++ b/main.go
@@ -1,20 +1,48 @@
 package main
 
 import (
-    "net/http"
-    "log"
+	"encoding/json"
+	"log"
+	"net/http"
 
-    "github.com/gorilla/mux"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
 )
 
+var wsMap map[int]*websocket.Conn
+var counter int
+
+type tester struct {
+	ID      int    `json:"id"`
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
+}
+
 func main() {
-    router := mux.NewRouter()
+	counter = 0
+	wsMap = make(map[int]*websocket.Conn)
 
-    router.HandleFunc("/", basicHandler)
+	router := mux.NewRouter()
 
-    log.Panic(http.ListenAndServe("localhost:1337", router))
+	router.HandleFunc("/ws", WsHandler)
+	router.Methods("POST").Path("/api/notification").HandlerFunc(notificationHandler)
+	router.PathPrefix("/").Handler(http.FileServer(http.Dir("static")))
+
+	log.Panic(http.ListenAndServe("localhost:1337", router))
 }
 
 func basicHandler(w http.ResponseWriter, r *http.Request) {
-    w.Write([]byte("Hello world!"))
+	w.Write([]byte("Hello world!"))
+}
+
+func notificationHandler(w http.ResponseWriter, r *http.Request) {
+	decoder := json.NewDecoder(r.Body)
+	t := &tester{}
+	err := decoder.Decode(t)
+
+	if err != nil {
+		log.Println(err)
+	}
+
+	wsMap[t.ID].WriteJSON(t)
 }

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+    <title>NaaSgul Test</title>
+
+    <script src="js/websocket.js"></script>
+</head>
+<body>
+    <h1>Test</h1>
+</body>
+</html>

--- a/static/js/websocket.js
+++ b/static/js/websocket.js
@@ -1,0 +1,9 @@
+var testSocket = new WebSocket("ws://localhost:1337/ws");
+
+testSocket.onopen = function(event) {
+    testSocket.send("THIS IS A TEST!");
+}
+
+testSocket.onmessage = function(event) {
+    console.log(event.data);
+}

--- a/wsserver.go
+++ b/wsserver.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+//WsHandler test
+func WsHandler(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	defer conn.Close()
+	wsMap[counter] = conn
+	counter++
+	log.Println("Received web socket connection: ", conn.RemoteAddr().String())
+
+	for {
+		messageType, p, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		log.Println(string(p))
+		if err = conn.WriteMessage(messageType, p); err != nil {
+			log.Println(err)
+		}
+	}
+}


### PR DESCRIPTION
Successfully set up a websocket connection from the browser to the server. Stored open connections in a map (using an int as an ID. Will probably be a GUID in the future) which allowed me to send a POST request to the server with notification information that was routed to the correct browser window.

Will need something a bit more robust in the future since users can potentially have multiple web sockets associated with them (or need to figure out how to consolidate them down to a single socket).
