### PR TITLE
Adding PushNotifications

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "go.formatTool": "goimports"
+}

--- a/entities/pushnotification.go
+++ b/entities/pushnotification.go
@@ -1,0 +1,56 @@
+package entities
+
+import "github.com/satori/go.uuid"
+
+type PushNotification struct {
+	Notification
+
+	subscriberID       uuid.UUID
+	subscriberClientID string
+	hasBeenSeen        bool
+}
+
+//NewPushNotification returns a pointer to a new PushNotification entity. In order to create a PushNotification, you need at least a Notification entity.
+//Depending on the type of operation that the entity will be used for, either the subscriberID or the subscriberClientID will also need set.
+func NewPushNotification(notification Notification) *PushNotification {
+	return &PushNotification{Notification: notification}
+}
+
+//SetNotification sets the embedded Notification entity.
+func (pn *PushNotification) SetNotification(notification Notification) {
+	pn.Notification = notification
+}
+
+//SetSubscriberID sets the subscriberID for the PushNotification. If the string given is not a valid UUID, an error will be returned.
+func (pn *PushNotification) SetSubscriberID(subscriberID string) error {
+	subID, err := uuid.FromString(subscriberID)
+	pn.subscriberID = subID
+
+	return err
+}
+
+//SetSubscriberClientID sets the subscriberClientID for the PushNotification. What this ID represents is determined by the end-user, but it can be used
+//to send notifications to particular subscribers.
+func (pn *PushNotification) SetSubscriberClientID(subscriberClientID string) {
+	pn.subscriberClientID = subscriberClientID
+}
+
+//SetHasBeenSeen sets the hasBeenSeen flag for the PushNotification.
+func (pn *PushNotification) SetHasBeenSeen(hasBeenSeen bool) {
+	pn.hasBeenSeen = hasBeenSeen
+}
+
+//SubscriberID of the PushNotification
+func (pn *PushNotification) SubscriberID() uuid.UUID {
+	return pn.subscriberID
+}
+
+//SubscriberClientID of the PushNotification.
+func (pn *PushNotification) SubscriberClientID() string {
+	return pn.subscriberClientID
+}
+
+//HasBeenSeen flag of the PushNotification.
+func (pn *PushNotification) HasBeenSeen() bool {
+	return pn.hasBeenSeen
+}

--- a/entities/pushnotification.go
+++ b/entities/pushnotification.go
@@ -3,7 +3,7 @@ package entities
 import "github.com/satori/go.uuid"
 
 type PushNotification struct {
-	Notification
+	*Notification
 
 	subscriberID       uuid.UUID
 	subscriberClientID string
@@ -12,12 +12,12 @@ type PushNotification struct {
 
 //NewPushNotification returns a pointer to a new PushNotification entity. In order to create a PushNotification, you need at least a Notification entity.
 //Depending on the type of operation that the entity will be used for, either the subscriberID or the subscriberClientID will also need set.
-func NewPushNotification(notification Notification) *PushNotification {
+func NewPushNotification(notification *Notification) *PushNotification {
 	return &PushNotification{Notification: notification}
 }
 
 //SetNotification sets the embedded Notification entity.
-func (pn *PushNotification) SetNotification(notification Notification) {
+func (pn *PushNotification) SetNotification(notification *Notification) {
 	pn.Notification = notification
 }
 

--- a/entities/pushnotification_test.go
+++ b/entities/pushnotification_test.go
@@ -1,0 +1,133 @@
+package entities
+
+import (
+	"testing"
+	"time"
+
+	"github.com/satori/go.uuid"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCreatingPushNotifications(t *testing.T) {
+	Convey("Given a valid Notification entity", t, func() {
+		subject := "testing"
+		body := "test body"
+		notifType := Text
+
+		notification := NewNotification(subject, body, notifType)
+		Convey("When NewPushNotification is called", func() {
+			pushNotification := NewPushNotification(*notification)
+
+			Convey("Then a new PushNotification entity should be returned", func() {
+				So(pushNotification, ShouldNotBeNil)
+				So(pushNotification.Subject(), ShouldEqual, subject)
+			})
+		})
+	})
+}
+
+func TestPushNotificationGetters(t *testing.T) {
+	Convey("Given a valid PushNotification entity", t, func() {
+		pushNotification := NewPushNotification(*NewNotification("testing", "test body", Text))
+		pushNotification.SetSubscriberID("b3a8ab73-41e1-4038-a27d-25f3ea64dcfc")
+		pushNotification.SetSubscriberClientID("12345")
+		pushNotification.SetHasBeenSeen(true)
+
+		Convey("When getting the SubscriberID", func() {
+			subscriberID := pushNotification.SubscriberID()
+
+			Convey("The subscriberID should be returned", func() {
+				So(subscriberID, ShouldNotBeNil)
+			})
+		})
+
+		Convey("When getting the SubscriberClientID", func() {
+			subscriberClientID := pushNotification.SubscriberClientID()
+
+			Convey("The subscriberClientID should be returned", func() {
+				So(subscriberClientID, ShouldNotBeNil)
+			})
+		})
+
+		Convey("When getting the HasBeenSeen flag", func() {
+			hasBeenSeen := pushNotification.HasBeenSeen()
+
+			Convey("The hasBeenSeen flag should be returned", func() {
+				So(hasBeenSeen, ShouldBeTrue)
+			})
+		})
+	})
+}
+
+func TestPushNotificationSetters(t *testing.T) {
+	Convey("Given a valid Notification entity", t, func() {
+		notification, _ := BuildNotification(uuid.NewV1().String(), "testing", "test body", "text", time.Now())
+
+		Convey("When attempting to set the notificationID with a UUID", func() {
+			id := uuid.NewV1()
+			notification.SetNotificationID(id)
+
+			Convey("Then the notificationID should be updated", func() {
+				So(notification.NotificationID(), ShouldEqual, id)
+			})
+		})
+
+		Convey("When attempting to build the notificationID", func() {
+			Convey("with a valid UUID string", func() {
+				id := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+				err := notification.BuildNotificationID(id)
+
+				Convey("Then the notificationID should be updated and no errors returned", func() {
+					So(err, ShouldBeNil)
+					So(notification.NotificationID().String(), ShouldEqual, id)
+				})
+			})
+
+			Convey("with an invalid UUID string", func() {
+				id := "this is bad"
+				err := notification.BuildNotificationID(id)
+
+				Convey("Then the notificationID should not be updated and an error should be returned", func() {
+					So(err, ShouldNotBeNil)
+					So(notification.NotificationID(), ShouldNotEqual, id)
+				})
+			})
+		})
+
+		Convey("When attempting to set the subject", func() {
+			subject := "new subject"
+			notification.SetSubject(subject)
+
+			Convey("Then the subject should be updated", func() {
+				So(notification.Subject(), ShouldEqual, subject)
+			})
+		})
+
+		Convey("When attempting to set the body", func() {
+			body := "new body"
+			notification.SetBody(body)
+
+			Convey("Then the body should be updated", func() {
+				So(notification.Body(), ShouldEqual, body)
+			})
+		})
+
+		Convey("When attempting to set the notificationType", func() {
+			notifType := HTML
+			notification.SetNotificationType(notifType)
+
+			Convey("Then the notificationType should be updated", func() {
+				So(notification.NotificationType(), ShouldEqual, notifType)
+			})
+		})
+
+		Convey("When attempting to set the createDate", func() {
+			createDate := time.Now()
+			notification.SetCreateDate(createDate)
+
+			Convey("Then the createDate should be updated", func() {
+				So(notification.CreateDate().Equal(createDate), ShouldBeTrue)
+			})
+		})
+	})
+}

--- a/entities/pushnotification_test.go
+++ b/entities/pushnotification_test.go
@@ -2,7 +2,6 @@ package entities
 
 import (
 	"testing"
-	"time"
 
 	"github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
@@ -16,7 +15,7 @@ func TestCreatingPushNotifications(t *testing.T) {
 
 		notification := NewNotification(subject, body, notifType)
 		Convey("When NewPushNotification is called", func() {
-			pushNotification := NewPushNotification(*notification)
+			pushNotification := NewPushNotification(notification)
 
 			Convey("Then a new PushNotification entity should be returned", func() {
 				So(pushNotification, ShouldNotBeNil)
@@ -28,7 +27,7 @@ func TestCreatingPushNotifications(t *testing.T) {
 
 func TestPushNotificationGetters(t *testing.T) {
 	Convey("Given a valid PushNotification entity", t, func() {
-		pushNotification := NewPushNotification(*NewNotification("testing", "test body", Text))
+		pushNotification := NewPushNotification(NewNotification("testing", "test body", Text))
 		pushNotification.SetSubscriberID("b3a8ab73-41e1-4038-a27d-25f3ea64dcfc")
 		pushNotification.SetSubscriberClientID("12345")
 		pushNotification.SetHasBeenSeen(true)
@@ -60,73 +59,46 @@ func TestPushNotificationGetters(t *testing.T) {
 }
 
 func TestPushNotificationSetters(t *testing.T) {
-	Convey("Given a valid Notification entity", t, func() {
-		notification, _ := BuildNotification(uuid.NewV1().String(), "testing", "test body", "text", time.Now())
+	Convey("Given a valid PushNotification entity", t, func() {
+		pushNotification := NewPushNotification(NewNotification("testing", "test body", Text))
+		pushNotification.SetSubscriberID("b3a8ab73-41e1-4038-a27d-25f3ea64dcfc")
+		pushNotification.SetSubscriberClientID("12345")
+		pushNotification.SetHasBeenSeen(true)
 
-		Convey("When attempting to set the notificationID with a UUID", func() {
+		Convey("When attempting to set the embedded Notification", func() {
+			notification := NewNotification("NewTest", "New body", HTML)
+
+			pushNotification.SetNotification(notification)
+			Convey("Then the embedded fields should be updated", func() {
+				So(pushNotification.Subject(), ShouldEqual, "NewTest")
+				So(pushNotification.NotificationType(), ShouldEqual, HTML)
+			})
+		})
+
+		Convey("When attempting to set the subscriberID", func() {
 			id := uuid.NewV1()
-			notification.SetNotificationID(id)
+			pushNotification.SetSubscriberID(id.String())
 
-			Convey("Then the notificationID should be updated", func() {
-				So(notification.NotificationID(), ShouldEqual, id)
+			Convey("Then the subscriberID should be updated", func() {
+				So(pushNotification.SubscriberID(), ShouldEqual, id)
 			})
 		})
 
-		Convey("When attempting to build the notificationID", func() {
-			Convey("with a valid UUID string", func() {
-				id := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
-				err := notification.BuildNotificationID(id)
+		Convey("When attempting to set the subscriberClientID", func() {
+			id := "9876"
+			pushNotification.SetSubscriberClientID(id)
 
-				Convey("Then the notificationID should be updated and no errors returned", func() {
-					So(err, ShouldBeNil)
-					So(notification.NotificationID().String(), ShouldEqual, id)
-				})
-			})
-
-			Convey("with an invalid UUID string", func() {
-				id := "this is bad"
-				err := notification.BuildNotificationID(id)
-
-				Convey("Then the notificationID should not be updated and an error should be returned", func() {
-					So(err, ShouldNotBeNil)
-					So(notification.NotificationID(), ShouldNotEqual, id)
-				})
+			Convey("Then the subscriberClientID should be updated", func() {
+				So(pushNotification.SubscriberClientID(), ShouldEqual, id)
 			})
 		})
 
-		Convey("When attempting to set the subject", func() {
-			subject := "new subject"
-			notification.SetSubject(subject)
+		Convey("When attempting to set the hasBeenSeen flag", func() {
+			hasBeenSeen := false
+			pushNotification.SetHasBeenSeen(hasBeenSeen)
 
-			Convey("Then the subject should be updated", func() {
-				So(notification.Subject(), ShouldEqual, subject)
-			})
-		})
-
-		Convey("When attempting to set the body", func() {
-			body := "new body"
-			notification.SetBody(body)
-
-			Convey("Then the body should be updated", func() {
-				So(notification.Body(), ShouldEqual, body)
-			})
-		})
-
-		Convey("When attempting to set the notificationType", func() {
-			notifType := HTML
-			notification.SetNotificationType(notifType)
-
-			Convey("Then the notificationType should be updated", func() {
-				So(notification.NotificationType(), ShouldEqual, notifType)
-			})
-		})
-
-		Convey("When attempting to set the createDate", func() {
-			createDate := time.Now()
-			notification.SetCreateDate(createDate)
-
-			Convey("Then the createDate should be updated", func() {
-				So(notification.CreateDate().Equal(createDate), ShouldBeTrue)
+			Convey("Then the hasBeenSeen flag should be updated", func() {
+				So(pushNotification.HasBeenSeen(), ShouldBeFalse)
 			})
 		})
 	})

--- a/handlers/notificationhandler.go
+++ b/handlers/notificationhandler.go
@@ -29,7 +29,7 @@ func initRouter(router *mux.Router) {
 //CreateNotification handles requests to create a new Notification.
 func CreateNotification(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
-	notification := &models.NotificationDTO{}
+	notification := &models.Notification{}
 
 	err := decoder.Decode(notification)
 
@@ -78,7 +78,7 @@ func GetNotificationByID(w http.ResponseWriter, r *http.Request) {
 //querystring parameters and building the proper request based on consumer supplied information.
 func GetNotifications(w http.ResponseWriter, r *http.Request) {
 	vars := r.URL.Query()
-	var notifications []*models.NotificationDTO
+	var notifications []*models.Notification
 	var err error
 
 	if subjects, ok := vars["subject"]; ok {

--- a/providers/mysql/models/notification.go
+++ b/providers/mysql/models/notification.go
@@ -27,13 +27,13 @@ func BuildNotificationFromEntity(entity *entities.Notification) *Notification {
 	}
 }
 
-//ToServiceModel converts NotificationDTO provider model
-func (n *Notification) ToServiceModel(models.Notification) {
+//ToServiceModel converts Notification provider model into a service model.
+func (n *Notification) ToServiceModel() *models.Notification {
 	return &models.Notification{
 		NotificationID:   n.NotificationID,
 		NotificationType: n.NotificationType,
 		Subject:          n.Subject,
 		Body:             n.Body,
-		CreateDate:       time.Unix(CreateDate, 0),
+		CreateDate:       time.Unix(n.CreateDate, 0),
 	}
 }

--- a/providers/mysql/models/notification.go
+++ b/providers/mysql/models/notification.go
@@ -1,0 +1,39 @@
+package models
+
+import (
+	"time"
+
+	"github.com/eriktate/NaaSgul/entities"
+	"github.com/eriktate/NaaSgul/services/models"
+)
+
+//Notification is a provider model for entities.Notification
+type Notification struct {
+	NotificationID   string `json:"notificationID" db:"NotificationId"`
+	Subject          string `json:"subject" db:"Subject"`
+	Body             string `json:"body" db:"Body"`
+	NotificationType string `json:"notificationType" db:"NotificationType"`
+	CreateDate       int64  `json:"createDate" db:"CreateDate"`
+}
+
+//BuildNotificationFromEntity returns the provider model representation of the given Notification entity.
+func BuildNotificationFromEntity(entity *entities.Notification) *Notification {
+	return &Notification{
+		NotificationID:   entity.NotificationID().String(),
+		Subject:          entity.Subject(),
+		Body:             entity.Body(),
+		NotificationType: string(entity.NotificationType()),
+		CreateDate:       entity.CreateDate().Unix(),
+	}
+}
+
+//ToServiceModel converts NotificationDTO provider model
+func (n *Notification) ToServiceModel(models.Notification) {
+	return &models.Notification{
+		NotificationID:   n.NotificationID,
+		NotificationType: n.NotificationType,
+		Subject:          n.Subject,
+		Body:             n.Body,
+		CreateDate:       time.Unix(CreateDate, 0),
+	}
+}

--- a/providers/mysql/models/pushnotification.go
+++ b/providers/mysql/models/pushnotification.go
@@ -1,0 +1,20 @@
+package models
+
+import "github.com/eriktate/NaaSgul/entities"
+
+type PushNotification struct {
+	Notification
+
+	SubscriberID       string `db:"subscriber_id"`
+	SubscriberClientID string `db:"subscriber_client_id"`
+	HasBeenSeen        bool   `db:"has_been_seen"`
+}
+
+func BuildPushNotificationFromEntity(entity entities.PushNotification) *PushNotification {
+	return &PushNotification{
+		Notification:       BuildNotificationFromEntity(&entity.Notification),
+		SubscriberID:       entity.SubscriberID().String(),
+		SubscriberClientID: entity.SubscriberClientID(),
+		HasBeenSeen:        entity.HasBeenSeen(),
+	}
+}

--- a/providers/mysql/models/pushnotification.go
+++ b/providers/mysql/models/pushnotification.go
@@ -2,17 +2,19 @@ package models
 
 import "github.com/eriktate/NaaSgul/entities"
 
+//PushNotification represents a PushNotification to be used in communicating with the MySQL database.
 type PushNotification struct {
-	Notification
+	*Notification
 
 	SubscriberID       string `db:"subscriber_id"`
 	SubscriberClientID string `db:"subscriber_client_id"`
 	HasBeenSeen        bool   `db:"has_been_seen"`
 }
 
-func BuildPushNotificationFromEntity(entity entities.PushNotification) *PushNotification {
+//BuildPushNotificationFromEntity converts a PushNotification entity into a PushNotification provider model.
+func BuildPushNotificationFromEntity(entity *entities.PushNotification) *PushNotification {
 	return &PushNotification{
-		Notification:       BuildNotificationFromEntity(&entity.Notification),
+		Notification:       BuildNotificationFromEntity(entity.Notification),
 		SubscriberID:       entity.SubscriberID().String(),
 		SubscriberClientID: entity.SubscriberClientID(),
 		HasBeenSeen:        entity.HasBeenSeen(),

--- a/services/mocks/notificationservice_mock.go
+++ b/services/mocks/notificationservice_mock.go
@@ -31,9 +31,9 @@ func (_m *MockNotificationRepo) EXPECT() *_MockNotificationRepoRecorder {
 	return _m.recorder
 }
 
-func (_m *MockNotificationRepo) CreateNotification(_param0 *entities.Notification) (*models.NotificationDTO, error) {
+func (_m *MockNotificationRepo) CreateNotification(_param0 *entities.Notification) (*models.Notification, error) {
 	ret := _m.ctrl.Call(_m, "CreateNotification", _param0)
-	ret0, _ := ret[0].(*models.NotificationDTO)
+	ret0, _ := ret[0].(*models.Notification)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -42,9 +42,9 @@ func (_mr *_MockNotificationRepoRecorder) CreateNotification(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNotification", arg0)
 }
 
-func (_m *MockNotificationRepo) GetNotificationByID(_param0 go_uuid.UUID) (*models.NotificationDTO, error) {
+func (_m *MockNotificationRepo) GetNotificationByID(_param0 go_uuid.UUID) (*models.Notification, error) {
 	ret := _m.ctrl.Call(_m, "GetNotificationByID", _param0)
-	ret0, _ := ret[0].(*models.NotificationDTO)
+	ret0, _ := ret[0].(*models.Notification)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -53,9 +53,9 @@ func (_mr *_MockNotificationRepoRecorder) GetNotificationByID(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetNotificationByID", arg0)
 }
 
-func (_m *MockNotificationRepo) GetNotificationsBySubject(_param0 string) []*models.NotificationDTO {
+func (_m *MockNotificationRepo) GetNotificationsBySubject(_param0 string) []*models.Notification {
 	ret := _m.ctrl.Call(_m, "GetNotificationsBySubject", _param0)
-	ret0, _ := ret[0].([]*models.NotificationDTO)
+	ret0, _ := ret[0].([]*models.Notification)
 	return ret0
 }
 

--- a/services/models/notification.go
+++ b/services/models/notification.go
@@ -6,8 +6,8 @@ import (
 	"github.com/eriktate/NaaSgul/entities"
 )
 
-//NotificationDTO is a data transfer object for entities.Notification
-type NotificationDTO struct {
+//Notification is a data transfer object for entities.Notification
+type Notification struct {
 	NotificationID   string    `json:"notificationID" db:"NotificationId"`
 	Subject          string    `json:"subject" db:"Subject"`
 	Body             string    `json:"body" db:"Body"`
@@ -15,8 +15,8 @@ type NotificationDTO struct {
 	CreateDate       time.Time `json:"createDate" db:"CreateDate"`
 }
 
-//BuildNotificationDTOFromEntity returns the DTO representation of the given Notification entity.
-func BuildNotificationDTOFromEntity(entity *entities.Notification) *NotificationDTO {
+//BuildNotificationFromEntity returns the DTO representation of the given Notification entity.
+func BuildNotificationFromEntity(entity *entities.Notification) *Notification {
 	return &NotificationDTO{
 		NotificationID:   entity.NotificationID().String(),
 		Subject:          entity.Subject(),
@@ -27,7 +27,7 @@ func BuildNotificationDTOFromEntity(entity *entities.Notification) *Notification
 }
 
 //ToEntity attempts to convert the NotificationDTO into a Notification entity.
-func (dto *NotificationDTO) ToEntity() (*entities.Notification, error) {
+func (dto *Notification) ToEntity() (*entities.Notification, error) {
 	if len(dto.NotificationID) > 0 {
 		return entities.BuildNotification(dto.NotificationID, dto.Subject, dto.Body, dto.NotificationType, dto.CreateDate)
 	}

--- a/services/models/notification.go
+++ b/services/models/notification.go
@@ -8,16 +8,16 @@ import (
 
 //Notification is a data transfer object for entities.Notification
 type Notification struct {
-	NotificationID   string    `json:"notificationID" db:"NotificationId"`
-	Subject          string    `json:"subject" db:"Subject"`
-	Body             string    `json:"body" db:"Body"`
-	NotificationType string    `json:"notificationType" db:"NotificationType"`
-	CreateDate       time.Time `json:"createDate" db:"CreateDate"`
+	NotificationID   string    `json:"notificationID"`
+	Subject          string    `json:"subject"`
+	Body             string    `json:"body"`
+	NotificationType string    `json:"notificationType"`
+	CreateDate       time.Time `json:"createDate"`
 }
 
-//BuildNotificationFromEntity returns the DTO representation of the given Notification entity.
+//BuildNotificationFromEntity returns the service model representation of the given Notification entity.
 func BuildNotificationFromEntity(entity *entities.Notification) *Notification {
-	return &NotificationDTO{
+	return &Notification{
 		NotificationID:   entity.NotificationID().String(),
 		Subject:          entity.Subject(),
 		Body:             entity.Body(),
@@ -26,7 +26,7 @@ func BuildNotificationFromEntity(entity *entities.Notification) *Notification {
 	}
 }
 
-//ToEntity attempts to convert the NotificationDTO into a Notification entity.
+//ToEntity attempts to convert the Notification into a Notification entity.
 func (dto *Notification) ToEntity() (*entities.Notification, error) {
 	if len(dto.NotificationID) > 0 {
 		return entities.BuildNotification(dto.NotificationID, dto.Subject, dto.Body, dto.NotificationType, dto.CreateDate)

--- a/services/models/pushnotification.go
+++ b/services/models/pushnotification.go
@@ -1,0 +1,18 @@
+package models
+
+//PushNotificationDTO represents a new notification that should be sent to a given subscriber.
+type PushNotificationDTO struct {
+	NotificationDTO
+
+	SubscriberID string `json:"subscriberId" db:"subscriber_id"`
+	HasBeenSeen  bool   `json:"hasBeenSeen" db:"has_been_seen"`
+}
+
+//NewPushNotificationDTO creates a new push notification given a valid notificationDTO and a subscriber ID.
+func NewPushNotificationDTO(notification NotificationDTO, subID string) *PushNotificationDTO {
+	return &PushNotificationDTO{
+		NotificationDTO: notification,
+		SubscriberID:    subID,
+		HasBeenSeen:     false,
+	}
+}

--- a/services/models/pushnotification.go
+++ b/services/models/pushnotification.go
@@ -4,9 +4,9 @@ package models
 type PushNotification struct {
 	Notification
 
-	SubscriberID        string `json:"subscriberId"`
-	SubsceriverClientID string `json:"subscriberClientId"`
-	HasBeenSeen         bool   `json:"hasBeenSeen"`
+	SubscriberID       string `json:"subscriberId"`
+	SubscriberClientID string `json:"subscriberClientId"`
+	HasBeenSeen        bool   `json:"hasBeenSeen"`
 }
 
 //NewPushNotification creates a new PushNotification model given a valid notification model and a subscriber ID.

--- a/services/models/pushnotification.go
+++ b/services/models/pushnotification.go
@@ -1,18 +1,19 @@
 package models
 
-//PushNotificationDTO represents a new notification that should be sent to a given subscriber.
-type PushNotificationDTO struct {
-	NotificationDTO
+//PushNotification represents a new notification that should be sent to a given subscriber.
+type PushNotification struct {
+	Notification
 
-	SubscriberID string `json:"subscriberId" db:"subscriber_id"`
-	HasBeenSeen  bool   `json:"hasBeenSeen" db:"has_been_seen"`
+	SubscriberID        string `json:"subscriberId"`
+	SubsceriverClientID string `json:"subscriberClientId"`
+	HasBeenSeen         bool   `json:"hasBeenSeen"`
 }
 
-//NewPushNotificationDTO creates a new push notification given a valid notificationDTO and a subscriber ID.
-func NewPushNotificationDTO(notification NotificationDTO, subID string) *PushNotificationDTO {
-	return &PushNotificationDTO{
-		NotificationDTO: notification,
-		SubscriberID:    subID,
-		HasBeenSeen:     false,
+//NewPushNotification creates a new PushNotification model given a valid notification model and a subscriber ID.
+func NewPushNotification(notification Notification, subID string) *PushNotification {
+	return &PushNotification{
+		Notification: notification,
+		SubscriberID: subID,
+		HasBeenSeen:  false,
 	}
 }

--- a/services/models/pushnotification.go
+++ b/services/models/pushnotification.go
@@ -1,8 +1,10 @@
 package models
 
+import "github.com/eriktate/NaaSgul/entities"
+
 //PushNotification represents a new notification that should be sent to a given subscriber.
 type PushNotification struct {
-	Notification
+	*Notification
 
 	SubscriberID       string `json:"subscriberId"`
 	SubscriberClientID string `json:"subscriberClientId"`
@@ -10,10 +12,27 @@ type PushNotification struct {
 }
 
 //NewPushNotification creates a new PushNotification model given a valid notification model and a subscriber ID.
-func NewPushNotification(notification Notification, subID string) *PushNotification {
+func NewPushNotification(notification *Notification, subID string) *PushNotification {
 	return &PushNotification{
 		Notification: notification,
 		SubscriberID: subID,
 		HasBeenSeen:  false,
 	}
+}
+
+//ToEntity creates a new PushNotification entity from the service model.
+func (pn *PushNotification) ToEntity() (*entities.PushNotification, error) {
+	notificationEntity, err := pn.Notification.ToEntity()
+
+	if err != nil {
+		return nil, err
+	}
+
+	pushEntity := entities.NewPushNotification(notificationEntity)
+
+	pushEntity.SetSubscriberID(pn.SubscriberID)
+	pushEntity.SetSubscriberClientID(pn.SubscriberClientID)
+	pushEntity.SetHasBeenSeen(pn.HasBeenSeen)
+
+	return pushEntity, nil
 }

--- a/services/notificationservice.go
+++ b/services/notificationservice.go
@@ -9,11 +9,11 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-//NotificationRepo is an interface that defines what a notification data source should look like.
+//NotificationRepo is an interface that defines what a notification repository should look like.
 type NotificationRepo interface {
-	CreateNotification(notification *entities.Notification) (*models.NotificationDTO, error)
-	GetNotificationByID(id uuid.UUID) (*models.NotificationDTO, error)
-	GetNotificationsBySubject(subject string) []*models.NotificationDTO
+	CreateNotification(notification *entities.Notification) (*models.Notification, error)
+	GetNotificationByID(id uuid.UUID) (*models.Notification, error)
+	GetNotificationsBySubject(subject string) []*models.Notification
 }
 
 //NotificationService exposes functions for interacting with notification data.
@@ -27,8 +27,8 @@ func NewNotificationService(repo NotificationRepo) *NotificationService {
 }
 
 //CreateNotification handles all requests for creating new notifications. To help with debugging, when errors occur
-//the service will also return the original NotificationDTO it was given.
-func (service *NotificationService) CreateNotification(notification *models.NotificationDTO) (*models.NotificationDTO, error) {
+//the service will also return the original Notification it was given.
+func (service *NotificationService) CreateNotification(notification *models.Notification) (*models.Notification, error) {
 	entity, err := notification.ToEntity()
 	if err != nil {
 		return notification, err
@@ -39,7 +39,7 @@ func (service *NotificationService) CreateNotification(notification *models.Noti
 
 //GetNotificationByID accepts either a string or UUID representation of a NotificationID. If the string is invalid or
 //you pass some other type, then an error is returned.
-func (service *NotificationService) GetNotificationByID(notificationID interface{}) (*models.NotificationDTO, error) {
+func (service *NotificationService) GetNotificationByID(notificationID interface{}) (*models.Notification, error) {
 	var id uuid.UUID
 	if result, ok := notificationID.(string); ok {
 		var err error
@@ -68,7 +68,7 @@ func (service *NotificationService) GetNotificationByID(notificationID interface
 
 //GetNotificationsBySubject will search for all notifications that have a subject containing the given string (string
 //length must be 5 characters or more).
-func (service *NotificationService) GetNotificationsBySubject(subject string) ([]*models.NotificationDTO, error) {
+func (service *NotificationService) GetNotificationsBySubject(subject string) ([]*models.Notification, error) {
 	if len(subject) < 5 {
 		return nil, errors.New("GetNOtificationsBySubject must be given a subject 5 characters or longer")
 	}

--- a/services/notificationservice_test.go
+++ b/services/notificationservice_test.go
@@ -19,20 +19,20 @@ func TestNotificationService(t *testing.T) {
 
 		notificationService := NewNotificationService(mockRepo)
 
-		Convey("And a valid NotificationDTO", func() {
-			notificationDTO := &models.NotificationDTO{
+		Convey("And a valid Notification", func() {
+			Notification := &models.Notification{
 				Subject:          "Test",
 				Body:             "Test",
 				NotificationType: "text",
 				CreateDate:       time.Now(),
 			}
 
-			newDTO := *notificationDTO
+			newDTO := *Notification
 			newDTO.NotificationID = "c48feb4f-44c1-4e83-8b1b-fb1408f0db28"
 
 			Convey("When we attempt to create a notification", func() {
 				mockRepo.EXPECT().CreateNotification(gomock.Any()).Return(&newDTO, nil).MinTimes(1)
-				returnedDTO, err := notificationService.CreateNotification(notificationDTO)
+				returnedDTO, err := notificationService.CreateNotification(Notification)
 
 				Convey("The NotificationRepo should be called and return no errors", func() {
 					So(returnedDTO.NotificationID, ShouldEqual, newDTO.NotificationID)
@@ -40,8 +40,8 @@ func TestNotificationService(t *testing.T) {
 				})
 			})
 
-			Convey("And an invalid NotificationDTO", func() {
-				notificationDTO := &models.NotificationDTO{
+			Convey("And an invalid Notification", func() {
+				Notification := &models.Notification{
 					NotificationID:   "bad ID",
 					Subject:          "Test",
 					Body:             "Test",
@@ -50,11 +50,11 @@ func TestNotificationService(t *testing.T) {
 				}
 
 				Convey("When we attempt to create a notification", func() {
-					mockRepo.EXPECT().CreateNotification(gomock.Any()).Return(notificationDTO, nil).MaxTimes(0)
-					returnedDTO, err := notificationService.CreateNotification(notificationDTO)
+					mockRepo.EXPECT().CreateNotification(gomock.Any()).Return(Notification, nil).MaxTimes(0)
+					returnedDTO, err := notificationService.CreateNotification(Notification)
 
 					Convey("Then the NotificationRepo should not be called, the original DTO should be returned, and an error should be returned", func() {
-						So(returnedDTO, ShouldEqual, notificationDTO)
+						So(returnedDTO, ShouldEqual, Notification)
 						So(err, ShouldNotBeNil)
 					})
 				})
@@ -65,7 +65,7 @@ func TestNotificationService(t *testing.T) {
 					notificationID := "c48feb4f-44c1-4e83-8b1b-fb1408f0db28"
 					uuidNotificationID, _ := uuid.FromString(notificationID)
 					Convey("When we call GetNotificationByID", func() {
-						mockRepo.EXPECT().GetNotificationByID(uuidNotificationID).Return(&models.NotificationDTO{}, nil).MinTimes(1)
+						mockRepo.EXPECT().GetNotificationByID(uuidNotificationID).Return(&models.Notification{}, nil).MinTimes(1)
 						_, err := notificationService.GetNotificationByID(notificationID)
 
 						Convey("Then the NotificationRepo should be called and no errors returned", func() {
@@ -76,7 +76,7 @@ func TestNotificationService(t *testing.T) {
 				Convey("When given a UUID NotificationID", func() {
 					notificationID := uuid.NewV1()
 					Convey("When we call GetNotificationbyID", func() {
-						mockRepo.EXPECT().GetNotificationByID(notificationID).Return(&models.NotificationDTO{}, nil).MinTimes(1)
+						mockRepo.EXPECT().GetNotificationByID(notificationID).Return(&models.Notification{}, nil).MinTimes(1)
 						_, err := notificationService.GetNotificationByID(notificationID)
 
 						Convey("Then the NotificationRepo should be called and no errors returned", func() {
@@ -108,7 +108,7 @@ func TestNotificationService(t *testing.T) {
 				})
 				Convey("When given a subject that is at least 5 characters", func() {
 					subject := "Testing"
-					notifications := make([]*models.NotificationDTO, 12)
+					notifications := make([]*models.Notification, 12)
 
 					Convey("When we call GetNotificationsBySubject", func() {
 						mockRepo.EXPECT().GetNotificationsBySubject(subject).Return(notifications).MinTimes(1)


### PR DESCRIPTION
This PR adds a PushNotification entity and models to go with it. A PushNotification is a struct of Subscriber information with a Notification embedded in it. It also contains a field for **HasBeenSeen** which is used to signal whether or not the subscriber has seen the notification.

Whenever a notification needs to be sent to specific subscribers, a push notification should be used to accomplish this.
